### PR TITLE
Use libc::_exit() for all invocations of _exit()

### DIFF
--- a/src/auto-str.rs
+++ b/src/auto-str.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_puts(arg1: *mut buffer, arg2: *const u8) -> i32;
     fn buffer_unixwrite(arg1: i32, arg2: *const u8, arg3: u32) -> i32;
@@ -36,7 +37,7 @@ pub static mut b: buffer = buffer {
 #[no_mangle]
 pub unsafe extern "C" fn puts(mut s: *const u8) {
     if buffer_puts(&mut b as (*mut buffer), s) == -1i32 {
-        _exit(111i32);
+        libc::_exit(111i32);
     }
 }
 
@@ -66,11 +67,11 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     let mut octal: [u8; 4];
     name = *argv.offset(1isize);
     if name.is_null() {
-        _exit(100i32);
+        libc::_exit(100i32);
     }
     value = *argv.offset(2isize);
     if value.is_null() {
-        _exit(100i32);
+        libc::_exit(100i32);
     }
     puts((*b"const char \0").as_ptr());
     puts(name as (*const u8));
@@ -98,8 +99,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     }
     puts((*b"\\\n\";\n\0").as_ptr());
     if buffer_flush(&mut b as (*mut buffer)) == -1i32 {
-        _exit(111i32);
+        libc::_exit(111i32);
     }
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/axfr-get.rs
+++ b/src/axfr-get.rs
@@ -4,7 +4,6 @@ use libc;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn _exit(arg1: i32);
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_get(arg1: *mut buffer, arg2: *mut u8, arg3: u32) -> i32;
     fn buffer_init(
@@ -1024,7 +1023,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     );
     if oldserial != 0 && (newserial != 0) {
         if oldserial == newserial {
-            _exit(0i32);
+            libc::_exit(0i32);
         }
     }
     fd = open_trunc(fntmp as (*const u8));
@@ -1126,6 +1125,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
             &mut strerr_sys as (*mut strerr) as (*const strerr),
         );
     }
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/axfrdns-conf.rs
+++ b/src/axfrdns-conf.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut auto_home: *const u8;
     fn finish();
     fn getpwnam(arg1: *const u8) -> *mut passwd;
@@ -209,6 +210,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     outs((*b":deny\n\0").as_ptr());
     finish();
     perm(0o644i32);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/axfrdns.rs
+++ b/src/axfrdns.rs
@@ -1,7 +1,7 @@
 use byte;
+use libc;
 
 extern "C" {
-    fn _exit(arg1: i32);
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_get(arg1: *mut buffer, arg2: *mut u8, arg3: u32) -> i32;
     fn buffer_init(
@@ -765,7 +765,7 @@ pub unsafe extern "C" fn netread(mut buf: *mut u8, mut len: u32) {
         }
         r = timeoutread(60i32, 0i32, buf, len as (i32));
         if r == 0i32 {
-            _exit(0i32);
+            libc::_exit(0i32);
         }
         if r < 0i32 {
             die_netread();

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,8 +1,8 @@
 use alloc;
 use byte;
+use libc;
 
 extern "C" {
-    fn _exit(arg1: i32);
     fn tai_add(arg1: *mut tai, arg2: *const tai, arg3: *const tai);
     fn tai_now(arg1: *mut tai);
     fn tai_pack(arg1: *mut u8, arg2: *const tai);
@@ -57,7 +57,7 @@ unsafe extern "C" fn hash(mut key: *const u8, mut keylen: u32) -> u32 {
 }
 
 unsafe extern "C" fn cache_impossible() {
-    _exit(111i32);
+    libc::_exit(111i32);
 }
 
 unsafe extern "C" fn get4(mut pos: u32) -> u32 {

--- a/src/cachetest.rs
+++ b/src/cachetest.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_put(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
@@ -53,7 +54,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     let mut u: u32;
     let mut ttl: u32;
     if cache_init(200u32) == 0 {
-        _exit(111i32);
+        libc::_exit(111i32);
     }
     if !(*argv).is_null() {
         argv = argv.offset(1isize);
@@ -95,6 +96,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         }
     }
     buffer_flush(buffer_1);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnscache-conf.rs
+++ b/src/dnscache-conf.rs
@@ -2,7 +2,6 @@ use errno::{errno, Errno};
 use libc;
 
 extern "C" {
-    fn _exit(arg1: i32);
     static mut auto_home: *const u8;
     fn buffer_init(
         arg1: *mut buffer,
@@ -439,6 +438,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     out(seed.as_mut_ptr() as (*mut u8) as (*const u8), 128u32);
     finish();
     perm(0o600i32);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnsfilter.rs
+++ b/src/dnsfilter.rs
@@ -4,7 +4,6 @@ use errno::errno;
 use libc;
 
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_put(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
@@ -633,6 +632,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
             }
         }
     }
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnsip.rs
+++ b/src/dnsip.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_put(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
@@ -157,6 +158,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         argv = argv.offset(1isize);
     }
     buffer_flush(buffer_1);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnsipq.rs
+++ b/src/dnsipq.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_put(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
@@ -166,6 +167,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         argv = argv.offset(1isize);
     }
     buffer_flush(buffer_1);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnsmx.rs
+++ b/src/dnsmx.rs
@@ -1,7 +1,7 @@
 use byte;
+use libc;
 
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_put(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
@@ -208,6 +208,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         argv = argv.offset(1isize);
     }
     buffer_flush(buffer_1);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnsname.rs
+++ b/src/dnsname.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_put(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
@@ -133,6 +134,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         argv = argv.offset(1isize);
     }
     buffer_flush(buffer_1);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnsq.rs
+++ b/src/dnsq.rs
@@ -3,7 +3,6 @@ use errno::errno;
 use libc;
 
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_putflush(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
     fn dns_domain_fromdot(arg1: *mut *mut u8, arg2: *const u8, arg3: u32) -> i32;
@@ -384,6 +383,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         oops();
     }
     buffer_putflush(buffer_1, out.s as (*const u8), out.len);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnsqr.rs
+++ b/src/dnsqr.rs
@@ -2,7 +2,6 @@ use errno::errno;
 use libc;
 
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_putflush(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
     fn dns_domain_fromdot(arg1: *mut *mut u8, arg2: *const u8, arg3: u32) -> i32;
@@ -266,6 +265,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         }
     }
     buffer_putflush(buffer_1, out.s as (*const u8), out.len);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnstrace.rs
+++ b/src/dnstrace.rs
@@ -4,7 +4,6 @@ use errno::{self, Errno};
 use libc;
 
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_put(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
@@ -1520,6 +1519,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         }
         i = i + 1;
     }
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/dnstxt.rs
+++ b/src/dnstxt.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_put(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
@@ -140,6 +141,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         argv = argv.offset(1isize);
     }
     buffer_flush(buffer_1);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/pickdns-conf.rs
+++ b/src/pickdns-conf.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut auto_home: *const u8;
     fn finish();
     fn getpwnam(arg1: *const u8) -> *mut passwd;
@@ -195,6 +196,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     outs((*b"/bin/pickdns-data\n\0").as_ptr());
     finish();
     perm(0o644i32);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/pickdns-data.rs
+++ b/src/pickdns-data.rs
@@ -1,9 +1,9 @@
 use alloc;
 use byte;
+use libc;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn _exit(arg1: i32);
     fn buffer_init(
         arg1: *mut buffer,
         arg2: unsafe extern "C" fn() -> i32,
@@ -806,6 +806,5 @@ pub unsafe extern "C" fn _c_main() -> i32 {
             &mut strerr_sys as (*mut strerr) as (*const strerr),
         );
     }
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/random-ip.rs
+++ b/src/random-ip.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_put(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
@@ -237,6 +238,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         buffer_puts(buffer_1, (*b"\n\0").as_ptr());
     }
     buffer_flush(buffer_1);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/rbldns-conf.rs
+++ b/src/rbldns-conf.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut auto_home: *const u8;
     fn finish();
     fn getpwnam(arg1: *const u8) -> *mut passwd;
@@ -207,6 +208,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     outs((*b"/bin/rbldns-data\n\0").as_ptr());
     finish();
     perm(0o644i32);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/rbldns-data.rs
+++ b/src/rbldns-data.rs
@@ -1,8 +1,8 @@
 use byte;
+use libc;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn _exit(arg1: i32);
     fn buffer_init(
         arg1: *mut buffer,
         arg2: unsafe extern "C" fn() -> i32,
@@ -533,6 +533,5 @@ pub unsafe extern "C" fn _c_main() -> i32 {
             &mut strerr_sys as (*mut strerr) as (*const strerr),
         );
     }
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/strerr_die.rs
+++ b/src/strerr_die.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_2: *mut buffer;
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_puts(arg1: *mut buffer, arg2: *const u8) -> i32;
@@ -97,5 +98,5 @@ pub unsafe extern "C" fn strerr_die(
     mut se: *const strerr,
 ) {
     strerr_warn(x1, x2, x3, x4, x5, x6, se);
-    _exit(e);
+    libc::_exit(e);
 }

--- a/src/tinydns-conf.rs
+++ b/src/tinydns-conf.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut auto_home: *const u8;
     fn finish();
     fn getpwnam(arg1: *const u8) -> *mut passwd;
@@ -235,6 +236,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     outs((*b"/bin/tinydns-data\n\0").as_ptr());
     finish();
     perm(0o644i32);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/tinydns-data.rs
+++ b/src/tinydns-data.rs
@@ -1,8 +1,8 @@
 use byte;
+use libc;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn _exit(arg1: i32);
     fn buffer_init(
         arg1: *mut buffer,
         arg2: unsafe extern "C" fn() -> i32,
@@ -1210,6 +1210,5 @@ pub unsafe extern "C" fn _c_main() -> i32 {
             &mut strerr_sys as (*mut strerr) as (*const strerr),
         );
     }
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/tinydns-edit.rs
+++ b/src/tinydns-edit.rs
@@ -1,8 +1,8 @@
 use byte;
+use libc;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn _exit(arg1: i32);
     fn buffer_flush(arg1: *mut buffer) -> i32;
     fn buffer_init(
         arg1: *mut buffer,
@@ -860,6 +860,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
             &mut strerr_sys as (*mut strerr) as (*const strerr),
         );
     }
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/tinydns-get.rs
+++ b/src/tinydns-get.rs
@@ -1,7 +1,7 @@
 use byte;
+use libc;
 
 extern "C" {
-    fn _exit(arg1: i32);
     static mut buffer_1: *mut buffer;
     fn buffer_putflush(arg1: *mut buffer, arg2: *const u8, arg3: u32) -> i32;
     fn case_lowerb(arg1: *mut u8, arg2: u32);
@@ -235,6 +235,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         }
     }
     buffer_putflush(buffer_1, out.s as (*const u8), out.len);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }

--- a/src/walldns-conf.rs
+++ b/src/walldns-conf.rs
@@ -1,5 +1,6 @@
+use libc;
+
 extern "C" {
-    fn _exit(arg1: i32);
     static mut auto_home: *const u8;
     fn finish();
     fn getpwnam(arg1: *const u8) -> *mut passwd;
@@ -185,6 +186,5 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     perm(0o755i32);
     makedir((*b"root\0").as_ptr());
     perm(0o2755i32);
-    _exit(0i32);
-    0
+    libc::_exit(0i32);
 }


### PR DESCRIPTION
We could probably use a better exit strategy in general, but this is a start