### PR TITLE
Type fixups for libc::strlen()

### DIFF
--- a/src/axfr-get.rs
+++ b/src/axfr-get.rs
@@ -886,7 +886,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     if dns_domain_fromdot(
         &mut zone as (*mut *mut u8),
         *argv as (*const u8),
-        libc::strlen(*argv as (*const u8)),
+        libc::strlen(*argv as *const i8) as u32,
     ) == 0
     {
         die_generate();

--- a/src/buffer_put.rs
+++ b/src/buffer_put.rs
@@ -163,15 +163,15 @@ pub unsafe extern "C" fn buffer_putflush(
 
 #[no_mangle]
 pub unsafe extern "C" fn buffer_putsalign(mut s: *mut buffer, mut buf: *const u8) -> i32 {
-    buffer_putalign(s, buf, libc::strlen(buf))
+    buffer_putalign(s, buf, libc::strlen(buf as *const i8) as u32)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn buffer_puts(mut s: *mut buffer, mut buf: *const u8) -> i32 {
-    buffer_put(s, buf, libc::strlen(buf))
+    buffer_put(s, buf, libc::strlen(buf as *const i8) as u32)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn buffer_putsflush(mut s: *mut buffer, mut buf: *const u8) -> i32 {
-    buffer_putflush(s, buf, libc::strlen(buf))
+    buffer_putflush(s, buf, libc::strlen(buf as *const i8) as u32)
 }

--- a/src/cachetest.rs
+++ b/src/cachetest.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
                 x as (*const u8),
                 i as (u32),
                 x.offset(i as (isize)).offset(1isize) as (*const u8),
-                libc::strlen(x as (*const u8))
+                libc::strlen(x as *const i8) as u32
                     .wrapping_sub(i as (u32))
                     .wrapping_sub(1u32),
                 86400u32,

--- a/src/dnsmx.rs
+++ b/src/dnsmx.rs
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
             if dns_domain_fromdot(
                 &mut q as (*mut *mut u8),
                 *argv as (*const u8),
-                libc::strlen(*argv as (*const u8)),
+                libc::strlen(*argv as *const i8) as u32,
             ) == 0
             {
                 nomem();

--- a/src/dnsq.rs
+++ b/src/dnsq.rs
@@ -327,7 +327,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     if dns_domain_fromdot(
         &mut q as (*mut *mut u8),
         *argv as (*const u8),
-        libc::strlen(*argv as (*const u8)),
+        libc::strlen(*argv as *const i8) as u32,
     ) == 0
     {
         oops();

--- a/src/dnsqr.rs
+++ b/src/dnsqr.rs
@@ -209,7 +209,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     if dns_domain_fromdot(
         &mut q as (*mut *mut u8),
         *argv as (*const u8),
-        libc::strlen(*argv as (*const u8)),
+        libc::strlen(*argv as *const i8) as u32,
     ) == 0
     {
         oops();

--- a/src/dnstrace.rs
+++ b/src/dnstrace.rs
@@ -1388,7 +1388,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     if dns_domain_fromdot(
         &mut q as (*mut *mut u8),
         *argv as (*const u8),
-        libc::strlen(*argv as (*const u8)),
+        libc::strlen(*argv as *const i8) as u32,
     ) == 0
     {
         nomem();

--- a/src/env.rs
+++ b/src/env.rs
@@ -13,7 +13,7 @@ pub unsafe extern "C" fn env_get(mut s: *const u8) -> *mut u8 {
     if s.is_null() {
         0i32 as (*mut u8)
     } else {
-        len = libc::strlen(s);
+        len = libc::strlen(s as *const i8) as u32;
         i = 0i32;
         'loop2: loop {
             if (*environ.offset(i as (isize))).is_null() {

--- a/src/rbldns.rs
+++ b/src/rbldns.rs
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn initialize() {
     if dns_domain_fromdot(
         &mut base as (*mut *mut u8),
         x as (*const u8),
-        libc::strlen(x as (*const u8)),
+        libc::strlen(x as *const i8) as u32,
     ) == 0
     {
         strerr_die(

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -193,7 +193,7 @@ unsafe extern "C" fn init2(mut dir: *mut Struct1) -> i32 {
         if str_diff(fqdn, (*b"@\0").as_ptr()) == 0 {
             fqdn = (*b".\0").as_ptr();
         }
-        if dns_domain_fromdot(&mut q as (*mut *mut u8), fqdn, libc::strlen(fqdn)) == 0 {
+        if dns_domain_fromdot(&mut q as (*mut *mut u8), fqdn, libc::strlen(fqdn as *const i8) as u32) == 0 {
             _currentBlock = 20;
             break;
         }

--- a/src/stralloc_cats.rs
+++ b/src/stralloc_cats.rs
@@ -20,5 +20,5 @@ impl Clone for stralloc {
 
 #[no_mangle]
 pub unsafe extern "C" fn stralloc_cats(mut sa: *mut stralloc, mut s: *const u8) -> i32 {
-    stralloc_catb(sa, s, libc::strlen(s))
+    stralloc_catb(sa, s, libc::strlen(s as *const i8) as u32)
 }

--- a/src/stralloc_opys.rs
+++ b/src/stralloc_opys.rs
@@ -20,5 +20,5 @@ impl Clone for stralloc {
 
 #[no_mangle]
 pub unsafe extern "C" fn stralloc_copys(mut sa: *mut stralloc, mut s: *const u8) -> i32 {
-    stralloc_copyb(sa, s, libc::strlen(s))
+    stralloc_copyb(sa, s, libc::strlen(s as *const i8) as u32)
 }

--- a/src/tinydns-edit.rs
+++ b/src/tinydns-edit.rs
@@ -430,7 +430,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     if dns_domain_fromdot(
         &mut target as (*mut *mut u8),
         *argv as (*const u8),
-        libc::strlen(*argv as (*const u8)),
+        libc::strlen(*argv as (*const i8)) as u32,
     ) == 0
     {
         nomem();

--- a/src/tinydns-get.rs
+++ b/src/tinydns-get.rs
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     if dns_domain_fromdot(
         &mut q as (*mut *mut u8),
         *argv as (*const u8),
-        libc::strlen(*argv as (*const u8)),
+        libc::strlen(*argv as *const i8) as u32,
     ) == 0
     {
         oops();


### PR DESCRIPTION
The libc version of `strlen()` takes a `const *i8` and returns a `usize`, which is a bit different from `str_len()` which took a `const *u8` and returns a `u32`.

This fixes all occurrances so (hopefully) the types match up!