### PR TITLE
src/buffer_1.rs, src/buffer_2.rs: build and rename constants

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -6,7 +6,7 @@ use byte;
 use errno::{errno, Errno};
 use libc;
 
-type Op = unsafe fn(i32, *const u8, u32) -> i32;
+pub type Op = unsafe fn(i32, *const u8, u32) -> i32;
 
 #[derive(Copy)]
 #[repr(C)]
@@ -37,6 +37,10 @@ impl Buffer {
         (*s).op = Some(op);
         (*s).p = 0u32;
         (*s).n = len;
+    }
+
+    pub unsafe fn as_mut_ptr(&mut self) -> *mut Self {
+        self as *mut Self
     }
 
     pub unsafe fn copy(bout: *mut Buffer, bin: *mut Buffer) -> i32 {

--- a/src/buffer_1.rs
+++ b/src/buffer_1.rs
@@ -1,15 +1,17 @@
+//! `buffer_1.rs`: an 8kB thread-unsafe static buffer used for STDOUT(?)
+//!
+//! TODO: document those things and find a better way to handle them
+
 use buffer::{self, Buffer};
 
-#[no_mangle]
-pub static mut buffer_1_space: [u8; 8192] = [0u8; 8192];
+const BUFFER_1_SIZE: usize = 8192;
 
-static mut it: Buffer = Buffer {
-    x: buffer_1_space.as_mut_ptr(),
+static mut BUFFER_1_SPACE: [u8; BUFFER_1_SIZE] = [0u8; BUFFER_1_SIZE];
+
+pub static mut BUFFER_1: Buffer = Buffer {
+    x: unsafe { &mut BUFFER_1_SPACE as *mut [u8] as *mut u8 },
     p: 0u32,
-    n: ::std::mem::size_of::<[u8; 8192]>() as (u32),
-    fd: 1i32,
+    n: BUFFER_1_SIZE as u32,
+    fd: 1i32, // STDOUT?
     op: Some(buffer::unixwrite as buffer::Op),
 };
-
-#[no_mangle]
-pub static mut buffer_1: *mut Buffer = &mut it as (*mut Buffer);

--- a/src/buffer_2.rs
+++ b/src/buffer_2.rs
@@ -1,15 +1,17 @@
+//! `buffer_2.rs`: a 256-byte thread-unsafe static buffer used for STDERR(?)
+//!
+//! TODO: document those things and find a better way to handle them
+
 use buffer::{self, Buffer};
 
-#[no_mangle]
-pub static mut buffer_2_space: [u8; 256] = [0u8; 256];
+const BUFFER_2_SIZE: usize = 256;
 
-static mut it: Buffer = Buffer {
-    x: buffer_2_space.as_mut_ptr(),
+static mut BUFFER_2_SPACE: [u8; BUFFER_2_SIZE] = [0u8; BUFFER_2_SIZE];
+
+pub static mut BUFFER_2: Buffer = Buffer {
+    x: unsafe { &mut BUFFER_2_SPACE as *mut [u8] as *mut u8 },
     p: 0u32,
-    n: ::std::mem::size_of::<[u8; 256]>() as (u32),
+    n: BUFFER_2_SIZE as u32,
     fd: 2i32,
     op: Some(buffer::unixwrite as buffer::Op),
 };
-
-#[no_mangle]
-pub static mut buffer_2: *mut Buffer = &mut it as (*mut Buffer);

--- a/src/cachetest.rs
+++ b/src/cachetest.rs
@@ -1,8 +1,8 @@
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use libc;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn cache_get(arg1: *const u8, arg2: u32, arg3: *mut u32, arg4: *mut u32) -> *mut u8;
     fn cache_init(arg1: u32) -> i32;
     fn cache_set(arg1: *const u8, arg2: u32, arg3: *const u8, arg4: u32, arg5: u32);
@@ -71,11 +71,11 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
                 &mut ttl as (*mut u32),
             );
             if !y.is_null() {
-                Buffer::put(buffer_1, y as (*const u8), u);
+                Buffer::put(BUFFER_1.as_mut_ptr(), y as (*const u8), u);
             }
-            Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+            Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
         }
     }
-    Buffer::flush(buffer_1);
+    Buffer::flush(BUFFER_1.as_mut_ptr());
     libc::_exit(0i32);
 }

--- a/src/dnsfilter.rs
+++ b/src/dnsfilter.rs
@@ -1,5 +1,6 @@
 use alloc;
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use byte;
 use errno::errno;
 use libc;
@@ -8,7 +9,6 @@ use tai::Tai;
 use taia::TaiA;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dns_name4_domain(arg1: *mut u8, arg2: *const u8);
     fn dns_name_packet(arg1: *mut StrAlloc, arg2: *const u8, arg3: u32) -> i32;
     fn dns_resolvconfip(arg1: *mut u8) -> i32;
@@ -439,21 +439,21 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         'loop23: loop {
             if xnum != 0 && ((*x.offset(0isize)).flagactive == 0) {
                 Buffer::put(
-                    buffer_1,
+                    BUFFER_1.as_mut_ptr(),
                     (*x.offset(0isize)).left.s as (*const u8),
                     (*x.offset(0isize)).left.len,
                 );
                 Buffer::put(
-                    buffer_1,
+                    BUFFER_1.as_mut_ptr(),
                     (*x.offset(0isize)).middle.s as (*const u8),
                     (*x.offset(0isize)).middle.len,
                 );
                 Buffer::put(
-                    buffer_1,
+                    BUFFER_1.as_mut_ptr(),
                     (*x.offset(0isize)).right.s as (*const u8),
                     (*x.offset(0isize)).right.len,
                 );
-                Buffer::flush(buffer_1);
+                Buffer::flush(BUFFER_1.as_mut_ptr());
                 xnum = xnum.wrapping_sub(1u32);
                 tmp = *x.offset(0isize);
                 i = 0i32;

--- a/src/dnsip.rs
+++ b/src/dnsip.rs
@@ -1,9 +1,9 @@
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use libc;
 use stralloc::StrAlloc;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dns_ip4(arg1: *mut StrAlloc, arg2: *const StrAlloc) -> i32;
     fn dns_random_init(arg1: *const u8);
     fn ip4_fmt(arg1: *mut u8, arg2: *const u8) -> u32;
@@ -115,16 +115,16 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
                 break;
             }
             Buffer::put(
-                buffer_1,
+                BUFFER_1.as_mut_ptr(),
                 str.as_mut_ptr() as (*const u8),
                 ip4_fmt(str.as_mut_ptr(), out.s.offset(i as (isize)) as (*const u8)),
             );
-            Buffer::puts(buffer_1, (*b" \0").as_ptr());
+            Buffer::puts(BUFFER_1.as_mut_ptr(), (*b" \0").as_ptr());
             i = i + 4i32;
         }
-        Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
         argv = argv.offset(1isize);
     }
-    Buffer::flush(buffer_1);
+    Buffer::flush(BUFFER_1.as_mut_ptr());
     libc::_exit(0i32);
 }

--- a/src/dnsipq.rs
+++ b/src/dnsipq.rs
@@ -1,9 +1,9 @@
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use libc;
 use stralloc::StrAlloc;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dns_ip4_qualify(arg1: *mut StrAlloc, arg2: *mut StrAlloc, arg3: *const StrAlloc) -> i32;
     fn dns_random_init(arg1: *const u8);
     fn ip4_fmt(arg1: *mut u8, arg2: *const u8) -> u32;
@@ -116,24 +116,24 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
                 &mut strerr_sys as (*mut strerr) as (*const strerr),
             );
         }
-        Buffer::put(buffer_1, fqdn.s as (*const u8), fqdn.len);
-        Buffer::puts(buffer_1, (*b" \0").as_ptr());
+        Buffer::put(BUFFER_1.as_mut_ptr(), fqdn.s as (*const u8), fqdn.len);
+        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b" \0").as_ptr());
         i = 0i32;
         'loop9: loop {
             if !((i + 4i32) as (u32) <= out.len) {
                 break;
             }
             Buffer::put(
-                buffer_1,
+                BUFFER_1.as_mut_ptr(),
                 str.as_mut_ptr() as (*const u8),
                 ip4_fmt(str.as_mut_ptr(), out.s.offset(i as (isize)) as (*const u8)),
             );
-            Buffer::puts(buffer_1, (*b" \0").as_ptr());
+            Buffer::puts(BUFFER_1.as_mut_ptr(), (*b" \0").as_ptr());
             i = i + 4i32;
         }
-        Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
         argv = argv.offset(1isize);
     }
-    Buffer::flush(buffer_1);
+    Buffer::flush(BUFFER_1.as_mut_ptr());
     libc::_exit(0i32);
 }

--- a/src/dnsmx.rs
+++ b/src/dnsmx.rs
@@ -1,11 +1,11 @@
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use byte;
 use libc;
 use stralloc::StrAlloc;
 use uint16;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dns_domain_fromdot(arg1: *mut *mut u8, arg2: *const u8, arg3: u32) -> i32;
     fn dns_domain_todot_cat(arg1: *mut StrAlloc, arg2: *const u8) -> i32;
     fn dns_mx(arg1: *mut StrAlloc, arg2: *const StrAlloc) -> i32;
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
             if StrAlloc::cats(&mut out as (*mut StrAlloc), (*b"\n\0").as_ptr()) == 0 {
                 nomem();
             }
-            Buffer::put(buffer_1, out.s as (*const u8), out.len);
+            Buffer::put(BUFFER_1.as_mut_ptr(), out.s as (*const u8), out.len);
         } else {
             i = 0i32;
             'loop10: loop {
@@ -157,22 +157,22 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
                     &mut pref as (*mut u16),
                 );
                 Buffer::put(
-                    buffer_1,
+                    BUFFER_1.as_mut_ptr(),
                     strnum.as_mut_ptr() as (*const u8),
                     fmt_ulong(strnum.as_mut_ptr(), pref as (usize)),
                 );
-                Buffer::puts(buffer_1, (*b" \0").as_ptr());
+                Buffer::puts(BUFFER_1.as_mut_ptr(), (*b" \0").as_ptr());
                 Buffer::put(
-                    buffer_1,
+                    BUFFER_1.as_mut_ptr(),
                     out.s.offset(i as (isize)).offset(2isize) as (*const u8),
                     j as (u32),
                 );
-                Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+                Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
                 i = i + (j + 3i32);
             }
         }
         argv = argv.offset(1isize);
     }
-    Buffer::flush(buffer_1);
+    Buffer::flush(BUFFER_1.as_mut_ptr());
     libc::_exit(0i32);
 }

--- a/src/dnsname.rs
+++ b/src/dnsname.rs
@@ -1,9 +1,9 @@
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use libc;
 use stralloc::StrAlloc;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dns_name4(arg1: *mut StrAlloc, arg2: *const u8) -> i32;
     fn dns_random_init(arg1: *const u8);
     fn ip4_scan(arg1: *const u8, arg2: *mut u8) -> u32;
@@ -98,10 +98,10 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
                 &mut strerr_sys as (*mut strerr) as (*const strerr),
             );
         }
-        Buffer::put(buffer_1, out.s as (*const u8), out.len);
-        Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+        Buffer::put(BUFFER_1.as_mut_ptr(), out.s as (*const u8), out.len);
+        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
         argv = argv.offset(1isize);
     }
-    Buffer::flush(buffer_1);
+    Buffer::flush(BUFFER_1.as_mut_ptr());
     libc::_exit(0i32);
 }

--- a/src/dnsq.rs
+++ b/src/dnsq.rs
@@ -1,5 +1,6 @@
 use byte;
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use errno::errno;
 use libc;
 use stralloc::StrAlloc;
@@ -8,7 +9,6 @@ use taia::TaiA;
 use uint16;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dns_domain_fromdot(arg1: *mut *mut u8, arg2: *const u8, arg3: u32) -> i32;
     fn dns_domain_todot_cat(arg1: *mut StrAlloc, arg2: *const u8) -> i32;
     fn dns_ip4_qualify(arg1: *mut StrAlloc, arg2: *mut StrAlloc, arg3: *const StrAlloc) -> i32;
@@ -322,6 +322,6 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     } else if printpacket_cat(&mut out as (*mut StrAlloc), tx.packet, tx.packetlen) == 0 {
         oops();
     }
-    Buffer::putflush(buffer_1, out.s as (*const u8), out.len);
+    Buffer::putflush(BUFFER_1.as_mut_ptr(), out.s as (*const u8), out.len);
     libc::_exit(0i32);
 }

--- a/src/dnsqr.rs
+++ b/src/dnsqr.rs
@@ -1,4 +1,5 @@
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use errno::errno;
 use libc;
 use stralloc::StrAlloc;
@@ -7,7 +8,6 @@ use taia::TaiA;
 use uint16;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dns_domain_fromdot(arg1: *mut *mut u8, arg2: *const u8, arg3: u32) -> i32;
     fn dns_domain_todot_cat(arg1: *mut StrAlloc, arg2: *const u8) -> i32;
     fn dns_random_init(arg1: *const u8);
@@ -192,6 +192,6 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
             oops();
         }
     }
-    Buffer::putflush(buffer_1, out.s as (*const u8), out.len);
+    Buffer::putflush(BUFFER_1.as_mut_ptr(), out.s as (*const u8), out.len);
     libc::_exit(0i32);
 }

--- a/src/dnstrace.rs
+++ b/src/dnstrace.rs
@@ -1,5 +1,6 @@
 use alloc;
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use byte;
 use errno::{self, Errno};
 use libc;
@@ -9,7 +10,6 @@ use taia::TaiA;
 use uint16;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dd(arg1: *const u8, arg2: *const u8, arg3: *mut u8) -> i32;
     fn dns_domain_copy(arg1: *mut *mut u8, arg2: *const u8) -> i32;
     fn dns_domain_equal(arg1: *const u8, arg2: *const u8) -> i32;
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn printdomain(mut d: *const u8) {
     if dns_domain_todot_cat(&mut tmp as (*mut StrAlloc), d) == 0 {
         nomem();
     }
-    Buffer::put(buffer_1, tmp.s as (*const u8), tmp.len);
+    Buffer::put(BUFFER_1.as_mut_ptr(), tmp.s as (*const u8), tmp.len);
 }
 
 #[derive(Copy)]
@@ -250,8 +250,8 @@ pub unsafe extern "C" fn resolve(mut q: *mut u8, mut qtype: *mut u8, mut ip: *mu
                 &mut stamp as (*mut TaiA) as (*const TaiA),
             ) != 0
             {
-                 Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
-                 Buffer::puts(buffer_1, (*b"ALERT:took more than 1 second\n\0").as_ptr());
+                 Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
+                 Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"ALERT:took more than 1 second\n\0").as_ptr());
              }
              0i32
          } else {
@@ -743,12 +743,12 @@ pub unsafe extern "C" fn ns_add(mut owner: *const u8, mut server: *const u8) {
     let mut x: ns;
     let mut i: i32;
     let mut j: i32;
-    Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
-    Buffer::puts(buffer_1, (*b"NS:\0").as_ptr());
+    Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
+    Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"NS:\0").as_ptr());
     printdomain(owner);
-    Buffer::puts(buffer_1, (*b":\0").as_ptr());
+    Buffer::puts(BUFFER_1.as_mut_ptr(), (*b":\0").as_ptr());
     printdomain(server);
-    Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+    Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
     i = 0i32;
     'loop1: loop {
         if !(i as (u32) < ns.len) {
@@ -819,16 +819,16 @@ pub unsafe extern "C" fn address_add(mut owner: *const u8, mut ip: *const u8) {
     let mut x: address;
     let mut i: i32;
     let mut j: i32;
-    Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
-    Buffer::puts(buffer_1, (*b"A:\0").as_ptr());
+    Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
+    Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"A:\0").as_ptr());
     printdomain(owner);
-    Buffer::puts(buffer_1, (*b":\0").as_ptr());
+    Buffer::puts(BUFFER_1.as_mut_ptr(), (*b":\0").as_ptr());
     Buffer::put(
-        buffer_1,
+        BUFFER_1.as_mut_ptr(),
         ipstr.as_mut_ptr() as (*const u8),
         ip4_fmt(ipstr.as_mut_ptr(), ip),
     );
-    Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+    Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
     i = 0i32;
     'loop1: loop {
         if !(i as (u32) < address.len) {
@@ -1078,13 +1078,13 @@ pub unsafe extern "C" fn parsepacket(
                             if dns_domain_equal(referral as (*const u8), control) != 0 ||
                                 dns_domain_suffix(referral as (*const u8), control) == 0
                             {
-                                Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
+                                Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
                                 Buffer::puts(
-                                    buffer_1,
+                                    BUFFER_1.as_mut_ptr(),
                                     (*b"ALERT:lame server; refers to \0").as_ptr(),
                                 );
                                 printdomain(referral as (*const u8));
-                                Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+                                Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
                                 return;
                             }
                         }
@@ -1165,19 +1165,19 @@ pub unsafe extern "C" fn parsepacket(
                         if _currentBlock == 60 {
                         } else if flagcname != 0 {
                             query_add(cname as (*const u8), dtype);
-                            Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
-                            Buffer::puts(buffer_1, (*b"CNAME:\0").as_ptr());
+                            Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
+                            Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"CNAME:\0").as_ptr());
                             printdomain(cname as (*const u8));
-                            Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+                            Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
                             return;
                         } else if rcode == 3u32 {
-                            Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
-                            Buffer::puts(buffer_1, (*b"NXDOMAIN\n\0").as_ptr());
+                            Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
+                            Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"NXDOMAIN\n\0").as_ptr());
                             return;
                         } else if flagout != 0 || flagsoa != 0 || flagreferral == 0 {
                             if flagout == 0 {
-                                Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
-                                Buffer::puts(buffer_1, (*b"NODATA\n\0").as_ptr());
+                                Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
+                                Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"NODATA\n\0").as_ptr());
                                 return;
                             } else {
                                 pos = posanswers;
@@ -1204,12 +1204,12 @@ pub unsafe extern "C" fn parsepacket(
                                     }
                                     if tmp.len != 0 {
                                         Buffer::put(
-                                            buffer_1,
+                                            BUFFER_1.as_mut_ptr(),
                                             querystr.s as (*const u8),
                                             querystr.len,
                                         );
-                                        Buffer::puts(buffer_1, (*b"answer:\0").as_ptr());
-                                        Buffer::put(buffer_1, tmp.s as (*const u8), tmp.len);
+                                        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"answer:\0").as_ptr());
+                                        Buffer::put(BUFFER_1.as_mut_ptr(), tmp.s as (*const u8), tmp.len);
                                     }
                                     j = j + 1;
                                 }
@@ -1219,10 +1219,10 @@ pub unsafe extern "C" fn parsepacket(
                                 }
                             }
                         } else if !(dns_domain_suffix(d, referral as (*const u8)) == 0) {
-                            Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
-                            Buffer::puts(buffer_1, (*b"see:\0").as_ptr());
+                            Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
+                            Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"see:\0").as_ptr());
                             printdomain(referral as (*const u8));
-                            Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+                            Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
                             return;
                         }
                     }
@@ -1231,13 +1231,13 @@ pub unsafe extern "C" fn parsepacket(
         }
     }
     x = libc::strerror(errno::errno().0);
-    Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
+    Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
     Buffer::puts(
-        buffer_1,
+        BUFFER_1.as_mut_ptr(),
         (*b"ALERT:unable to parse response packet; \0").as_ptr(),
     );
-    Buffer::puts(buffer_1, x);
-    Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+    Buffer::puts(BUFFER_1.as_mut_ptr(), x);
+    Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
 }
 
 fn main() {
@@ -1416,15 +1416,15 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
             if StrAlloc::cats(&mut querystr as (*mut StrAlloc), (*b":\0").as_ptr()) == 0 {
                 nomem();
             }
-            Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
-            Buffer::puts(buffer_1, (*b"tx\n\0").as_ptr());
-            Buffer::flush(buffer_1);
+            Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
+            Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"tx\n\0").as_ptr());
+            Buffer::flush(BUFFER_1.as_mut_ptr());
             if resolve(q, type_.as_mut_ptr(), ip.as_mut_ptr()) == -1i32 {
                 let mut x = libc::strerror(errno::errno().0);
-                Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
-                Buffer::puts(buffer_1, (*b"ALERT:query failed; \0").as_ptr());
-                Buffer::puts(buffer_1, x);
-                Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+                Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
+                Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"ALERT:query failed; \0").as_ptr());
+                Buffer::puts(BUFFER_1.as_mut_ptr(), x);
+                Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
             } else {
                 parsepacket(
                     tx.packet as (*const u8),
@@ -1435,22 +1435,22 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
                 );
             }
             if dns_domain_equal(q as (*const u8), (*b"\tlocalhost\0\0").as_ptr()) != 0 {
-                Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
+                Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
                 Buffer::puts(
-                    buffer_1,
+                    BUFFER_1.as_mut_ptr(),
                     (*b"ALERT:some caches do not handle localhost internally\n\0").as_ptr(),
                 );
                 address_add(q as (*const u8), (*b"\x7F\0\0\x01\0").as_ptr());
             }
             if dd(q as (*const u8), (*b"\0").as_ptr(), ip.as_mut_ptr()) == 4i32 {
-                Buffer::put(buffer_1, querystr.s as (*const u8), querystr.len);
+                Buffer::put(BUFFER_1.as_mut_ptr(), querystr.s as (*const u8), querystr.len);
                 Buffer::puts(
-                    buffer_1,
+                    BUFFER_1.as_mut_ptr(),
                     (*b"ALERT:some caches do not handle IP addresses internally\n\0").as_ptr(),
                 );
                 address_add(q as (*const u8), ip.as_mut_ptr() as (*const u8));
             }
-            Buffer::flush(buffer_1);
+            Buffer::flush(BUFFER_1.as_mut_ptr());
         }
         i = i + 1;
     }

--- a/src/dnstxt.rs
+++ b/src/dnstxt.rs
@@ -1,9 +1,9 @@
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use libc;
 use stralloc::StrAlloc;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dns_random_init(arg1: *const u8);
     fn dns_txt(arg1: *mut StrAlloc, arg2: *const StrAlloc) -> i32;
     fn strerr_die(
@@ -104,10 +104,10 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
                 &mut strerr_sys as (*mut strerr) as (*const strerr),
             );
         }
-        Buffer::put(buffer_1, out.s as (*const u8), out.len);
-        Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+        Buffer::put(BUFFER_1.as_mut_ptr(), out.s as (*const u8), out.len);
+        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
         argv = argv.offset(1isize);
     }
-    Buffer::flush(buffer_1);
+    Buffer::flush(BUFFER_1.as_mut_ptr());
     libc::_exit(0i32);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ extern crate libc;
 /// covered by CI to ensure the code compiles.
 mod alloc;
 mod buffer;
+mod buffer_1;
+mod buffer_2;
 mod byte;
 mod stralloc;
 mod tai;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,5 @@
 use buffer::Buffer;
+use buffer_2::BUFFER_2;
 use byte;
 use errno::{self, Errno};
 use libc;
@@ -6,7 +7,6 @@ use uint16;
 use uint32;
 
 extern "C" {
-    static mut buffer_2: *mut Buffer;
     static mut cache_motion: usize;
     static mut numqueries: usize;
     static mut tactive: i32;
@@ -16,12 +16,12 @@ extern "C" {
 static mut u64: usize = 0usize;
 
 unsafe extern "C" fn string(mut s: *const u8) {
-    Buffer::puts(buffer_2, s);
+    Buffer::puts(BUFFER_2.as_mut_ptr(), s);
 }
 
 unsafe extern "C" fn line() {
     string((*b"\n\0").as_ptr());
-    Buffer::flush(buffer_2);
+    Buffer::flush(BUFFER_2.as_mut_ptr());
 }
 
 #[no_mangle]
@@ -48,7 +48,7 @@ unsafe extern "C" fn u64_print() {
         }
     }
     Buffer::put(
-        buffer_2,
+        BUFFER_2.as_mut_ptr(),
         buf.as_mut_ptr().offset(pos as (isize)) as (*const u8),
         ::std::mem::size_of::<[u8; 20]>().wrapping_sub(pos as (usize)) as (u32),
     );
@@ -60,7 +60,7 @@ unsafe extern "C" fn space() {
 
 unsafe extern "C" fn hex(mut c: u8) {
     Buffer::put(
-        buffer_2,
+        BUFFER_2.as_mut_ptr(),
         (*b"0123456789abcdef\0").as_ptr().offset(
             (c as (i32) >> 4i32) as
                 (isize),
@@ -68,7 +68,7 @@ unsafe extern "C" fn hex(mut c: u8) {
         1u32,
     );
     Buffer::put(
-        buffer_2,
+        BUFFER_2.as_mut_ptr(),
         (*b"0123456789abcdef\0").as_ptr().offset(
             (c as (i32) & 15i32) as
                 (isize),
@@ -130,7 +130,7 @@ unsafe extern "C" fn name(mut q: *const u8) {
                 if ch as (i32) >= b'A' as (i32) && (ch as (i32) <= b'Z' as (i32)) {
                     ch = (ch as (i32) + 32i32) as (u8);
                 }
-                Buffer::put(buffer_2, &mut ch as (*mut u8) as (*const u8), 1u32);
+                Buffer::put(BUFFER_2.as_mut_ptr(), &mut ch as (*mut u8) as (*const u8), 1u32);
             }
             string((*b".\0").as_ptr());
         }

--- a/src/qlog.rs
+++ b/src/qlog.rs
@@ -1,11 +1,8 @@
 use buffer::Buffer;
-
-extern "C" {
-    static mut buffer_2: *mut Buffer;
-}
+use buffer_2::BUFFER_2;
 
 unsafe extern "C" fn put(mut c: u8) {
-    Buffer::put(buffer_2, &mut c as (*mut u8) as (*const u8), 1u32);
+    Buffer::put(BUFFER_2.as_mut_ptr(), &mut c as (*mut u8) as (*const u8), 1u32);
 }
 
 unsafe extern "C" fn hex(mut c: u8) {
@@ -43,7 +40,7 @@ pub unsafe extern "C" fn qlog(
     put(b':');
     hex(*id.offset(0isize));
     hex(*id.offset(1isize));
-    Buffer::puts(buffer_2, result);
+    Buffer::puts(BUFFER_2.as_mut_ptr(), result);
     hex(*qtype.offset(0isize));
     hex(*qtype.offset(1isize));
     put(b' ');
@@ -90,5 +87,5 @@ pub unsafe extern "C" fn qlog(
         }
     }
     put(b'\n');
-    Buffer::flush(buffer_2);
+    Buffer::flush(BUFFER_2.as_mut_ptr());
 }

--- a/src/random-ip.rs
+++ b/src/random-ip.rs
@@ -1,8 +1,8 @@
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use libc;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn dns_random(arg1: u32) -> u32;
     fn dns_random_init(arg1: *const u8);
     fn fmt_ulong(arg1: *mut u8, arg2: usize) -> u32;
@@ -192,33 +192,33 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
         }
         u = ip[0usize] as (usize);
         Buffer::put(
-            buffer_1,
+            BUFFER_1.as_mut_ptr(),
             strnum.as_mut_ptr() as (*const u8),
             fmt_ulong(strnum.as_mut_ptr(), u),
         );
-        Buffer::puts(buffer_1, (*b".\0").as_ptr());
+        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b".\0").as_ptr());
         u = ip[1usize] as (usize);
         Buffer::put(
-            buffer_1,
+            BUFFER_1.as_mut_ptr(),
             strnum.as_mut_ptr() as (*const u8),
             fmt_ulong(strnum.as_mut_ptr(), u),
         );
-        Buffer::puts(buffer_1, (*b".\0").as_ptr());
+        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b".\0").as_ptr());
         u = ip[2usize] as (usize);
         Buffer::put(
-            buffer_1,
+            BUFFER_1.as_mut_ptr(),
             strnum.as_mut_ptr() as (*const u8),
             fmt_ulong(strnum.as_mut_ptr(), u),
         );
-        Buffer::puts(buffer_1, (*b".\0").as_ptr());
+        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b".\0").as_ptr());
         u = ip[3usize] as (usize);
         Buffer::put(
-            buffer_1,
+            BUFFER_1.as_mut_ptr(),
             strnum.as_mut_ptr() as (*const u8),
             fmt_ulong(strnum.as_mut_ptr(), u),
         );
-        Buffer::puts(buffer_1, (*b"\n\0").as_ptr());
+        Buffer::puts(BUFFER_1.as_mut_ptr(), (*b"\n\0").as_ptr());
     }
-    Buffer::flush(buffer_1);
+    Buffer::flush(BUFFER_1.as_mut_ptr());
     libc::_exit(0i32);
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,8 +1,8 @@
 use buffer::Buffer;
+use buffer_2::BUFFER_2;
 use byte;
 
 extern "C" {
-    static mut buffer_2: *mut Buffer;
     fn case_lowerb(arg1: *mut u8, arg2: u32);
     fn dns_domain_length(arg1: *const u8) -> u32;
     fn dns_packet_copy(arg1: *const u8, arg2: u32, arg3: u32, arg4: *mut u8, arg5: u32) -> u32;
@@ -293,7 +293,7 @@ pub unsafe extern "C" fn _c_main() -> i32 {
     initialize();
     ndelay_off(udp53);
     socket_tryreservein(udp53, 65536i32);
-    Buffer::putsflush(buffer_2, starting as (*const u8));
+    Buffer::putsflush(BUFFER_2.as_mut_ptr(), starting as (*const u8));
     'loop9: loop {
         len = socket_recv4(
             udp53,

--- a/src/sgetopt.rs
+++ b/src/sgetopt.rs
@@ -1,7 +1,7 @@
 use buffer::Buffer;
+use buffer_2::BUFFER_2;
 
 extern "C" {
-    static mut buffer_2: *mut Buffer;
     fn subgetopt(arg1: i32, arg2: *mut *mut u8, arg3: *const u8) -> i32;
     static mut subgetoptind: i32;
     static mut subgetoptproblem: i32;
@@ -43,14 +43,14 @@ pub unsafe extern "C" fn sgetoptmine(
             let mut chp: [u8; 2];
             chp[0usize] = subgetoptproblem as (u8);
             chp[1usize] = b'\n';
-            Buffer::puts(buffer_2, sgetoptprogname);
+            Buffer::puts(BUFFER_2.as_mut_ptr(), sgetoptprogname);
             if !(*argv.offset(subgetoptind as (isize))).is_null() && (subgetoptind < argc) {
-                Buffer::puts(buffer_2, (*b": illegal option -- \0").as_ptr());
+                Buffer::puts(BUFFER_2.as_mut_ptr(), (*b": illegal option -- \0").as_ptr());
             } else {
-                Buffer::puts(buffer_2, (*b": option requires an argument -- \0").as_ptr());
+                Buffer::puts(BUFFER_2.as_mut_ptr(), (*b": option requires an argument -- \0").as_ptr());
             }
-            Buffer::put(buffer_2, chp.as_mut_ptr() as (*const u8), 2u32);
-            Buffer::flush(buffer_2);
+            Buffer::put(BUFFER_2.as_mut_ptr(), chp.as_mut_ptr() as (*const u8), 2u32);
+            Buffer::flush(BUFFER_2.as_mut_ptr());
         }
     }
     c

--- a/src/strerr_die.rs
+++ b/src/strerr_die.rs
@@ -1,8 +1,8 @@
 use buffer::Buffer;
+use buffer_2::BUFFER_2;
 use libc;
 
 extern "C" {
-    static mut buffer_2: *mut Buffer;
     fn strerr_sysinit();
 }
 
@@ -33,40 +33,40 @@ pub unsafe extern "C" fn strerr_warn(
 ) {
     strerr_sysinit();
     if !x1.is_null() {
-        Buffer::puts(buffer_2, x1);
+        Buffer::puts(BUFFER_2.as_mut_ptr(), x1);
     }
     if !x2.is_null() {
-        Buffer::puts(buffer_2, x2);
+        Buffer::puts(BUFFER_2.as_mut_ptr(), x2);
     }
     if !x3.is_null() {
-        Buffer::puts(buffer_2, x3);
+        Buffer::puts(BUFFER_2.as_mut_ptr(), x3);
     }
     if !x4.is_null() {
-        Buffer::puts(buffer_2, x4);
+        Buffer::puts(BUFFER_2.as_mut_ptr(), x4);
     }
     if !x5.is_null() {
-        Buffer::puts(buffer_2, x5);
+        Buffer::puts(BUFFER_2.as_mut_ptr(), x5);
     }
     if !x6.is_null() {
-        Buffer::puts(buffer_2, x6);
+        Buffer::puts(BUFFER_2.as_mut_ptr(), x6);
     }
     'loop12: loop {
         if se.is_null() {
             break;
         }
         if !(*se).x.is_null() {
-            Buffer::puts(buffer_2, (*se).x);
+            Buffer::puts(BUFFER_2.as_mut_ptr(), (*se).x);
         }
         if !(*se).y.is_null() {
-            Buffer::puts(buffer_2, (*se).y);
+            Buffer::puts(BUFFER_2.as_mut_ptr(), (*se).y);
         }
         if !(*se).z.is_null() {
-            Buffer::puts(buffer_2, (*se).z);
+            Buffer::puts(BUFFER_2.as_mut_ptr(), (*se).z);
         }
         se = (*se).who as (*const strerr);
     }
-    Buffer::puts(buffer_2, (*b"\n\0").as_ptr());
-    Buffer::flush(buffer_2);
+    Buffer::puts(BUFFER_2.as_mut_ptr(), (*b"\n\0").as_ptr());
+    Buffer::flush(BUFFER_2.as_mut_ptr());
 }
 
 #[no_mangle]

--- a/src/tinydns-get.rs
+++ b/src/tinydns-get.rs
@@ -1,11 +1,11 @@
 use byte;
 use buffer::Buffer;
+use buffer_1::BUFFER_1;
 use libc;
 use stralloc::StrAlloc;
 use uint16;
 
 extern "C" {
-    static mut buffer_1: *mut Buffer;
     fn case_lowerb(arg1: *mut u8, arg2: u32);
     fn dns_domain_fromdot(arg1: *mut *mut u8, arg2: *const u8, arg3: u32) -> i32;
     fn dns_domain_length(arg1: *const u8) -> u32;
@@ -201,6 +201,6 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
             oops();
         }
     }
-    Buffer::putflush(buffer_1, out.s as (*const u8), out.len);
+    Buffer::putflush(BUFFER_1.as_mut_ptr(), out.s as (*const u8), out.len);
     libc::_exit(0i32);
 }


### PR DESCRIPTION
These modules contain thread-unsafe static buffers. We should eventually get rid of them but for now make sure they compile.

Renames `buffer_1` => `BUFFER_1`, `buffer_2` => `BUFFER_2`