### PR TITLE
Use libc::close()

### DIFF
--- a/src/axfr-get.rs
+++ b/src/axfr-get.rs
@@ -13,7 +13,6 @@ use ulong;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn close(arg1: i32) -> i32;
     fn fsync(arg1: i32) -> i32;
     fn getln(arg1: *mut Buffer, arg2: *mut StrAlloc, arg3: *mut i32, arg4: i32) -> i32;
     fn rename(__old: *const u8, __new: *const u8) -> i32;
@@ -856,7 +855,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
             ulong::scan(line.s.offset(1isize) as (*const u8), &mut u as (*mut usize));
             oldserial = u as (u32);
         }
-        close(fd);
+        libc::close(fd);
     }
     if StrAlloc::copyb(
         &mut packet as (*mut StrAlloc),
@@ -1028,7 +1027,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     if fsync(fd) == -1i32 {
         die_write();
     }
-    if close(fd) == -1i32 {
+    if libc::close(fd) == -1i32 {
         die_write();
     }
     if rename(fntmp as (*const u8), filename as (*const u8)) == -1i32 {

--- a/src/axfrdns.rs
+++ b/src/axfrdns.rs
@@ -14,7 +14,6 @@ use uint32;
 use ulong;
 
 extern "C" {
-    fn close(arg1: i32) -> i32;
     fn droproot(arg1: *const u8);
     fn qlog(
         arg1: *const u8,
@@ -820,7 +819,7 @@ pub unsafe extern "C" fn _c_main() -> i32 {
                 die_cdbread();
             }
             doaxfr(header.as_mut_ptr());
-            close(fdcdb);
+            libc::close(fdcdb);
         } else {
             if response_query(
                 zone as (*const u8),

--- a/src/dnscache.rs
+++ b/src/dnscache.rs
@@ -15,7 +15,6 @@ use ulong;
 
 extern "C" {
     fn cache_init(arg1: u32) -> i32;
-    fn close(arg1: i32) -> i32;
     fn droproot(arg1: *const u8);
     fn log_query(
         arg1: *mut usize,
@@ -462,7 +461,7 @@ pub unsafe extern "C" fn t_close(mut j: i32) {
             t[j as (usize)].ip.as_mut_ptr() as (*const u8),
             t[j as (usize)].port as (u32),
         );
-        close(t[j as (usize)].tcp);
+        libc::close(t[j as (usize)].tcp);
         t[j as (usize)].active = 0usize;
         tactive = tactive - 1;
     }
@@ -644,14 +643,14 @@ pub unsafe extern "C" fn t_new() {
     } else {
         if (*x).port as (i32) < 1024i32 {
             if (*x).port as (i32) != 53i32 {
-                close((*x).tcp);
+                libc::close((*x).tcp);
                 return;
             }
         }
         (if okclient((*x).ip.as_mut_ptr()) == 0 {
-             close((*x).tcp);
+             libc::close((*x).tcp);
          } else if ndelay::on((*x).tcp) == -1i32 {
-             close((*x).tcp);
+             libc::close((*x).tcp);
          } else {
              (*x).active = 1usize;
              tactive = tactive + 1;
@@ -930,7 +929,7 @@ pub unsafe extern "C" fn _c_main() -> i32 {
         ::std::mem::size_of::<[u8; 128]>(),
     );
     dns::random::init(seed.as_mut_ptr() as (*const u8));
-    close(0i32);
+    libc::close(0i32);
     x = libc::getenv((*b"IPSEND\0").as_ptr() as *const libc::c_char);
     if x.is_null() {
         StrErr::die(

--- a/src/generic-conf.rs
+++ b/src/generic-conf.rs
@@ -6,7 +6,6 @@ extern "C" {
     fn chdir(arg1: *const u8) -> i32;
     fn chmod(arg1: *const u8, arg2: u16) -> i32;
     fn chown(arg1: *const u8, arg2: u32, arg3: u32) -> i32;
-    fn close(arg1: i32) -> i32;
     fn fsync(arg1: i32) -> i32;
     fn mkdir(arg1: *const u8, arg2: u16) -> i32;
     fn umask(arg1: u16) -> u16;
@@ -140,7 +139,7 @@ pub unsafe extern "C" fn finish() {
     if fsync(fd) == -1i32 {
         fail();
     }
-    close(fd);
+    libc::close(fd);
 }
 
 #[no_mangle]

--- a/src/pickdns-data.rs
+++ b/src/pickdns-data.rs
@@ -13,7 +13,6 @@ use ulong;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn close(arg1: i32) -> i32;
     fn fsync(arg1: i32) -> i32;
     fn getln(arg1: *mut Buffer, arg2: *mut StrAlloc, arg3: *mut i32, arg4: i32) -> i32;
     fn rename(__old: *const u8, __new: *const u8) -> i32;
@@ -588,7 +587,7 @@ pub unsafe extern "C" fn _c_main() -> i32 {
             syntaxerror((*b": unrecognized leading character\0").as_ptr());
         }
     }
-    close(fd);
+    libc::close(fd);
     address_sort(x.s, x.len);
     i = 0i32;
     'loop10: loop {
@@ -665,7 +664,7 @@ pub unsafe extern "C" fn _c_main() -> i32 {
     if fsync(fdcdb) == -1i32 {
         die_datatmp();
     }
-    if close(fdcdb) == -1i32 {
+    if libc::close(fdcdb) == -1i32 {
         die_datatmp();
     }
     if rename((*b"data.tmp\0").as_ptr(), (*b"data.cdb\0").as_ptr()) == -1i32 {

--- a/src/pickdns.rs
+++ b/src/pickdns.rs
@@ -5,7 +5,6 @@ use dns;
 use open;
 
 extern "C" {
-    fn close(arg1: i32) -> i32;
     static mut response: *mut u8;
     fn response_addbytes(arg1: *const u8, arg2: u32) -> i32;
     fn response_rfinish(arg1: i32);
@@ -190,7 +189,7 @@ pub unsafe extern "C" fn respond(mut q: *mut u8, mut qtype: *mut u8, mut ip: *mu
         Cdb::init(&mut c as (*mut Cdb), fd);
         result = doit(q, qtype, ip);
         Cdb::free(&mut c as (*mut Cdb));
-        close(fd);
+        libc::close(fd);
         result
     }
 }

--- a/src/rbldns-data.rs
+++ b/src/rbldns-data.rs
@@ -10,7 +10,6 @@ use ulong;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn close(arg1: i32) -> i32;
     fn fsync(arg1: i32) -> i32;
     fn getln(arg1: *mut Buffer, arg2: *mut StrAlloc, arg3: *mut i32, arg4: i32) -> i32;
     fn rename(__old: *const u8, __new: *const u8) -> i32;
@@ -394,7 +393,7 @@ pub unsafe extern "C" fn _c_main() -> i32 {
     if fsync(fdcdb) == -1i32 {
         die_datatmp();
     }
-    if close(fdcdb) == -1i32 {
+    if libc::close(fdcdb) == -1i32 {
         die_datatmp();
     }
     if rename((*b"data.tmp\0").as_ptr(), (*b"data.cdb\0").as_ptr()) == -1i32 {

--- a/src/rbldns.rs
+++ b/src/rbldns.rs
@@ -8,7 +8,6 @@ use uint32;
 use strerr::StrErr;
 
 extern "C" {
-    fn close(arg1: i32) -> i32;
     fn dd(arg1: *const u8, arg2: *const u8, arg3: *mut u8) -> i32;
     static mut response: *mut u8;
     fn response_addbytes(arg1: *const u8, arg2: u32) -> i32;
@@ -208,7 +207,7 @@ pub unsafe extern "C" fn respond(mut q: *mut u8, mut qtype: *mut u8, mut ip: *mu
         Cdb::init(&mut c as (*mut Cdb), fd);
         result = doit(q, qtype);
         Cdb::free(&mut c as (*mut Cdb));
-        close(fd);
+        libc::close(fd);
         result
     }
 }

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -10,7 +10,6 @@ use string;
 
 extern "C" {
     fn chdir(arg1: *const u8) -> i32;
-    fn close(arg1: i32) -> i32;
     fn closedir(arg1: *mut Struct1) -> i32;
     fn fchdir(arg1: i32) -> i32;
     fn opendir(arg1: *const u8) -> *mut Struct1;
@@ -272,7 +271,7 @@ pub unsafe extern "C" fn roots_init() -> i32 {
              if fchdir(fddir) == -1i32 {
                  r = 0i32;
              }
-             close(fddir);
+             libc::close(fddir);
              r
          })
     }

--- a/src/tdlookup.rs
+++ b/src/tdlookup.rs
@@ -2,13 +2,13 @@ use byte;
 use case;
 use cdb::Cdb;
 use dns;
+use libc;
 use open;
 use tai::Tai;
 use uint16;
 use uint32;
 
 extern "C" {
-    fn close(arg1: i32) -> i32;
     static mut response: *mut u8;
     fn response_addbytes(arg1: *const u8, arg2: u32) -> i32;
     fn response_addname(arg1: *const u8) -> i32;
@@ -815,7 +815,7 @@ pub unsafe extern "C" fn respond(mut q: *mut u8, mut qtype: *mut u8, mut ip: *mu
              }
              r = doit(q, qtype);
              Cdb::free(&mut c as (*mut Cdb));
-             close(fd);
+             libc::close(fd);
              r
          })
     }

--- a/src/tinydns-data.rs
+++ b/src/tinydns-data.rs
@@ -14,7 +14,6 @@ use ulong;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn close(arg1: i32) -> i32;
     fn fstat(arg1: i32, arg2: *mut stat) -> i32;
     fn fsync(arg1: i32) -> i32;
     fn getln(arg1: *mut Buffer, arg2: *mut StrAlloc, arg3: *mut i32, arg4: i32) -> i32;
@@ -1067,7 +1066,7 @@ pub unsafe extern "C" fn _c_main() -> i32 {
     if fsync(fdcdb) == -1i32 {
         die_datatmp();
     }
-    if close(fdcdb) == -1i32 {
+    if libc::close(fdcdb) == -1i32 {
         die_datatmp();
     }
     if rename((*b"data.tmp\0").as_ptr(), (*b"data.cdb\0").as_ptr()) == -1i32 {

--- a/src/tinydns-edit.rs
+++ b/src/tinydns-edit.rs
@@ -11,7 +11,6 @@ use ulong;
 
 extern "C" {
     fn __swbuf(arg1: i32, arg2: *mut __sFILE) -> i32;
-    fn close(arg1: i32) -> i32;
     fn fchmod(arg1: i32, arg2: u16) -> i32;
     fn fstat(arg1: i32, arg2: *mut stat) -> i32;
     fn fsync(arg1: i32) -> i32;
@@ -770,7 +769,7 @@ pub unsafe extern "C" fn _c_main(mut argc: i32, mut argv: *mut *mut u8) -> i32 {
     if fsync(fdnew) == -1i32 {
         die_write();
     }
-    if close(fdnew) == -1i32 {
+    if libc::close(fdnew) == -1i32 {
         die_write();
     }
     if rename(fnnew as (*const u8), filename as (*const u8)) == -1i32 {


### PR DESCRIPTION
Replaces all usages of close() via extern "C" with calls to the libc crate